### PR TITLE
Update 09_temperature.cpp to fix redundant string

### DIFF
--- a/2-variables/09_temperature.cpp
+++ b/2-variables/09_temperature.cpp
@@ -9,5 +9,5 @@ int main() {
 
   celsius = (fahrenheit - 32) / 1.8;
 
-  std::cout << "Temperature in Brooklyn, NY is " << celsius << " ℃ in Celsius.\n";
+  std::cout << "Temperature in Brooklyn, NY is " << celsius << " ℃.\n";
 }


### PR DESCRIPTION
The "in Celsius" is made redundant by the "℃", which clarifies degrees Celsius.