### PR TITLE
Update 12_cat_years.cpp to fix cat min age typo in welcome string

### DIFF
--- a/2-variables/12_cat_years.cpp
+++ b/2-variables/12_cat_years.cpp
@@ -7,7 +7,7 @@ int main() {
   int catAge;
   int humanYears;
 
-  std::cout << "Welcome to the Cat Years program! This only works for cats older than 3 years old.\n";
+  std::cout << "Welcome to the Cat Years program! This only works for cats 3+ years old.\n";
   std::cout << "Enter your cat's age: ";
   std::cin >> catAge;
 


### PR DESCRIPTION
Fix typo in welcome message. Original specified cats "older than 3 years old." Changed to "3+ years old." to fit exercise instructions.