### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Welcome to the C++ GitHub repo! We are super excited to have you. Here, you will
 
 <!-- link not applied yet ^-^ -->
 
-- [`declearation.cpp`]()
+- [`declaration_of_independence.cpp`]()
 - [`ipo.cpp`]()
 - [`temperature.cpp`]()
 - [`knighthood.cpp`]()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Welcome to the C++ GitHub repo! We are super excited to have you. Here, you will
 
 <!-- link not applied yet ^-^ -->
 
-- [`declaration_of_independence.cpp`]()
+- [`declaration.cpp`]()
 - [`ipo.cpp`]()
 - [`temperature.cpp`]()
 - [`knighthood.cpp`]()


### PR DESCRIPTION
Hello team,

I would like to propose a fix to a typo from README.md.

declearation.cpp -> declaration_of_independence.cpp (which is the actual name of the lesson).

Let's get it.