### PR TITLE
 Replaced and with &&

### DIFF
--- a/3-conditionals/17_voting.cpp
+++ b/3-conditionals/17_voting.cpp
@@ -8,7 +8,7 @@ int main() {
   bool citizen = true;
   bool registered = false;
 
-  if (age >= 18 and citizen == true and registered == true) {
+  if (age >= 18 && citizen == true && registered == true) { // Use '&&' instead of 'and'
     std::cout << "You can vote!\n";
   }
   else if (age < 18) {


### PR DESCRIPTION
Replaced and with && to ensure compatibility across all C++ compilers ...{&& is the standard logical "and" operator used in C++ programming}